### PR TITLE
Fix always recompiling C source on every build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
     let src_dir = PathBuf::from("./lib/libpg_query").canonicalize().unwrap();
     println!(
         "cargo:rerun-if-changed={}",
-        build_dir.join("pg_query.h").display()
+        src_dir.join("pg_query.h").display()
     );
 
     // Copy the files over


### PR DESCRIPTION
src_dir is freshly copied to build_dir on every build, meaning that build_dir/pg_query.h always has a new mtime and triggers a recompile on each build