### PR TITLE
Version 0.13 - Update libpg_query to 17-6.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_parse"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bindgen",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pg_parse"
 description = "PostgreSQL parser that uses the actual PostgreSQL server source to parse SQL queries and return the internal PostgreSQL parse tree."
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 edition = "2024"
 documentation = "https://docs.rs/pg_parse/"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add the following to your `Cargo.toml`
 
 ```toml
 [dependencies]
-pg_parse = "0.12"
+pg_parse = "0.13"
 ```
 
 ## Example: Parsing a query

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,3 +1,11 @@
+# Version 0.13
+
+Modified:
+
+* Updated `libpg_query` to [17-6.2.2](https://github.com/pganalyze/libpg_query/tree/17-6.2.2). This bumps the embedded
+  Postgres version from 17.4 to 17.7. No AST changes are introduced.
+* `build.rs` updated so that cross-compiling to alternative targets works.
+
 # Version 0.12
 
 **This release upgrades `libpg_query` so contains breaking changes.**


### PR DESCRIPTION
Bumps the embedded Postgres version from 17.4 to 17.7. The libpg_query update is purely additive at the C API level; `srcdata` is unchanged so the generated AST is identical.